### PR TITLE
Add @voidly/agent-sdk — hybrid X25519 + ML-KEM-768 messaging SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Go:
 JavaScript:
 
 * [paulmillr/noble-post-quantum](https://github.com/paulmillr/noble-post-quantum) - ML-KEM, ML-DSA, SLH-DSA, Falcon, and hybrids 
+* [@voidly/agent-sdk](https://www.npmjs.com/package/@voidly/agent-sdk) - E2E agent-to-agent messaging SDK using hybrid X25519 + ML-KEM-768 key exchange (via [mlkem](https://www.npmjs.com/package/mlkem))
 
 
 .NET:


### PR DESCRIPTION
Adds [`@voidly/agent-sdk`](https://www.npmjs.com/package/@voidly/agent-sdk) to the JavaScript libraries section. It's a published npm package (v3.4.9) providing end-to-end encrypted agent-to-agent messaging with a hybrid X25519 + ML-KEM-768 key exchange for harvest-now-decrypt-later resistance.

The PQ layer wraps the [`mlkem`](https://www.npmjs.com/package/mlkem) package (NIST FIPS 203 final) — credited inline in the entry so the actual implementation is not misattributed. The hybrid kex is one layer of a larger protocol (X3DH + Double Ratchet + sealed sender + padding); see [agent-relay-protocol.md](https://github.com/voidly-ai/voidly-pay/blob/main/agent-relay-protocol.md) for the full spec.

Maintainer: @EmperorMew.