### PR TITLE
Add QuantumScan to PQC software

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,9 @@ Tencent:
 
 ## PQC software
 
-* [SUPERCOP](https://bench.cr.yp.to/results-kem.html) - Benchmarks for cryptographic software
 * [PQConnect](https://www.pqconnect.net/) - Network-layer PQ-protected tunneling
+* [QuantumScan](https://quantumscan.io/) - Free scanner that detects RSA, ECDSA, SHA-1 and other quantum-vulnerable algorithms in GitHub repositories. Exports CycloneDX 1.7 CBOM and DORA/NIS2 compliance reports. ([open source scanner core](https://github.com/quantumscan-io/scanner-core))
+* [SUPERCOP](https://bench.cr.yp.to/results-kem.html) - Benchmarks for cryptographic software
 
 
 ### General-purpose libraries with PQC support


### PR DESCRIPTION
Adding **[QuantumScan](https://quantumscan.io/)** to the `## PQC software` section, listed alphabetically between PQConnect and SUPERCOP.

QuantumScan is a free scanner that detects quantum-vulnerable cryptography (RSA, ECDSA, Diffie-Hellman, SHA-1, etc.) in GitHub repositories. Output includes:

- **CycloneDX 1.7 CBOM** export (the cryptographic-asset specification recommended by CISA for inventory)
- **DORA / NIS2 compliance PDF** report aligned with EU regulatory requirements
- AI-generated migration guides per finding suggesting NIST FIPS 203/204/205 alternatives

The **scanner core is open source under the MIT license** at https://github.com/quantumscan-io/scanner-core so users can audit / self-host the detection logic. The web app is free during the design partner phase.

This fits in the same category as SUPERCOP (benchmarking) and PQConnect (network tooling) — practical software that helps developers actually adopt post-quantum primitives rather than libraries implementing the primitives themselves.

Listed alphabetically as requested in the README contribution guidelines.