### PR TITLE
Add vesvault/subtlepq (JavaScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Go:
 JavaScript:
 
 * [paulmillr/noble-post-quantum](https://github.com/paulmillr/noble-post-quantum) - ML-KEM, ML-DSA, SLH-DSA, Falcon, and hybrids 
+* [vesvault/subtlepq](https://github.com/vesvault/subtlepq) - ML-KEM and ML-DSA polyfill for the Web Cryptography API (WICG modern-algos draft), with delegation to native implementations and a DHKEM (RFC 9180) adapter for ECDH-to-KEM migration
 
 
 .NET:


### PR DESCRIPTION
Adds subtlepq under PQC software / JavaScript, alphabetically after noble-post-quantum.

subtlepq is a polyfill of the WICG Modern Algorithms draft: ML-KEM (FIPS 203) and ML-DSA (FIPS 204) on `crypto.subtle`, including the draft's `encapsulateBits`/`encapsulateKey`/`decapsulateBits`/`decapsulateKey`/`getPublicKey`/`supports` methods and key formats (seed/SPKI/PKCS#8/JWK `AKP`). It delegates per algorithm to native implementations where present (e.g. Node >= 24.7), so it complements noble-post-quantum (raw primitives) by covering the WebCrypto API shape. It also ships a DHKEM (RFC 9180 sec 4.1) extension over native ECDH as an ECDH-to-KEM migration path.

Apache-2.0; engine is a minimal liboqs wasm build (75 KB, reproducible); tested against NIST ACVP vectors, RFC 9180 Appendix A vectors, and byte-parity with Node's native ML-KEM/ML-DSA.