### PR TITLE
Add Elara Mesh under Blockchains

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ Circle/Arc:
   Roadmap](https://6778953.fs1.hubspotusercontent-na1.net/hubfs/6778953/PDFs/quantum_paper.pdf):
   "Arc will deploy a precompiled post-quantum signature verifier on mainnet (**SLH-DSA-SHA2-128s**) so smart accounts can validate post-quantum signatures on-chain."
 
+Elara Mesh:
+
+* [navigatorbuilds/elara-mesh](https://github.com/navigatorbuilds/elara-mesh) - Post-quantum-native validation mesh in Rust (ML-DSA/Dilithium3 signatures throughout), with an offline receipt verifier
+
 Ethereum: 
 
 * [Post-quantum cryptography on Ethereum](https://ethereum.org/roadmap/future-proofing/quantum-resistance/)


### PR DESCRIPTION
Adds Elara Mesh alphabetically under **Blockchains** (between Circle/Arc and Ethereum).

Elara Mesh is an open-source (AGPL-3.0 node, MIT/Apache-2.0 SDKs) post-quantum-native validation mesh in Rust — ML-DSA (Dilithium3) signatures throughout rather than a migration plan, plus an offline receipt verifier usable without joining the network.

Disclosure: this PR was prepared by the project's AI maintainer (documented in the repo) and submitted from the project owner's account.