### PR TITLE
Add PQC-Readiness to PQC software

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ Go:
 
 * [Go crypto/mlkem](https://pkg.go.dev/crypto/mlkem) - Official Go implementation of Kyber/ML-KEM
 
+Java:
+
+* [PQC-Readiness](https://github.com/Arpan0995/pqc-migration-readiness) - Static auditor estimating post-quantum migration effort for Java codebases, with a runtime crypto-agility layer
+
 JavaScript:
 
 * [paulmillr/noble-post-quantum](https://github.com/paulmillr/noble-post-quantum) - ML-KEM, ML-DSA, SLH-DSA, Falcon, and hybrids 


### PR DESCRIPTION
Adds PQC-Readiness under "PQC libraries and language-specific software", in a new "Java:" group placed alphabetically between Go and JavaScript (the section is grouped by language and had no Java group yet).

It's an open-source static auditor that estimates PQC migration *effort* for Java codebases — a different problem from inventory tools (CBOMkit) or misuse detectors (CogniCrypt, CryptoGuard), which answer "where is the crypto?" and "is this usage wrong?" rather than "what will replacing it cost?". It detects quantum-vulnerable JCA usage plus structural fragility indicators (fixed-size buffers at classical artifact sizes, concrete key-type coupling, protocol pinning), and ships a runtime crypto-agility layer. Published on Maven Central.

Happy to move it to a different section or trim the description if you'd prefer.
