### PR TITLE
Add quantakrypto pqc-tools to Other resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,5 +373,6 @@ Zcash:
 * [PQCrypto Usage & Deployment](https://ianix.com/pqcrypto/pqcrypto-deployment.html)
 * [PQC Forum](https://groups.google.com/a/list.nist.gov/g/pqc-forum) - NIST's discussion list
 * [PQ-SORT: Post-Quantum Signatures On-Ramp Tests](https://pqsort.tii.ae/)
+* [quantakrypto pqc-tools](https://quantakrypto.com/tools) - Open-source scanner + CycloneDX CBOM generator for quantum-vulnerable crypto, with NIST PQC migration guidance ([source](https://github.com/quantakrypto/pqc-tools))
 * [Quantum Algorithm Zoo](https://quantumalgorithmzoo.org)
 


### PR DESCRIPTION
Adds **quantakrypto pqc-tools** to *Other resources* (alphabetically, between PQ-SORT and Quantum Algorithm Zoo).

An open-source (Apache-2.0) scanner that inventories quantum-vulnerable asymmetric crypto (RSA/ECDH/ECDSA/DH/DSA) across source, IaC, config and dependencies, emits a CycloneDX CBOM, and gives NIST ML-KEM/ML-DSA/SLH-DSA migration guidance. Zero runtime dependencies.

- Source: https://github.com/quantakrypto/pqc-tools
- Tools page: https://quantakrypto.com/tools